### PR TITLE
fix:选项卡片部分问题修复

### DIFF
--- a/src/components/assessment/questionnaire-list.tsx
+++ b/src/components/assessment/questionnaire-list.tsx
@@ -418,8 +418,18 @@ export function QuestionnaireList({
                           return (
                             <div 
                               key={option.value}
+                              onClick={() => handleAnswer(question.id, option.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  handleAnswer(question.id, option.value);
+                                }
+                              }}
+                              role="radio"
+                              aria-checked={isSelected}
+                              tabIndex={0}
                               className={`
-                                flex items-center p-2 sm:p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer hover:bg-white/50
+                                flex items-center p-2 sm:p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer hover:bg-white/50 select-none active:scale-[0.98]
                                 ${isSelected 
                                   ? 'bg-white border-psychology-primary shadow-sm' 
                                   : 'bg-white/30 border-gray-300 hover:border-gray-400'


### PR DESCRIPTION
## 问题说明
外层 div 有 cursor-pointer 样式，看起来整个区域都可点击，但实际上只有 RadioGroupItem 和 Label 文字部分可以触发选择。当用户点击到 div 的内边距（padding）或边框区域时，就会选不上。
这是一个点击区域不完整的 UX bug。
## 修复
为选项卡片添加 `onClick` 事件，现在点击整个卡片都能选中选项。

## 额外优化
- 添加键盘支持（Tab/Enter/Space）
- 添加点击动画效果
- 改善无障碍体验