### PR TITLE
fix(ui): 修复首页按钮悬停样式问题

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -118,7 +118,7 @@ export default function Home() {
                 </Link>
                 
                 <Link to="/assessment?type=full">
-                  <Button size="lg" variant="outline" className="border-psychology-primary text-psychology-primary hover:bg-psychology-primary/5 px-8 py-4 text-lg">
+                  <Button size="lg" variant="outline" className="border-psychology-primary text-psychology-primary hover:bg-psychology-primary hover:text-white transition-colors px-8 py-4 text-lg">
                     <Target className="w-5 h-5 mr-2" />
                     完整版测评
                   </Button>
@@ -265,7 +265,7 @@ export default function Home() {
                   </div>
 
                   <Link to="/assessment?type=full" className="block">
-                    <Button variant="outline" className="w-full border-psychology-secondary text-psychology-secondary hover:bg-psychology-secondary/5">
+                    <Button variant="outline" className="w-full border-psychology-secondary text-psychology-secondary hover:bg-psychology-secondary hover:text-white transition-colors">
                       开始完整测评
                       <ArrowRight className="w-4 h-4 ml-2" />
                     </Button>
@@ -369,7 +369,7 @@ export default function Home() {
                     立即开始测评
                   </Button>
                 </Link>
-                <Button size="lg" variant="outline" asChild className="border-psychology-primary text-psychology-primary hover:bg-psychology-primary/5 px-8 py-4">
+                <Button size="lg" variant="outline" asChild className="border-psychology-primary text-psychology-primary hover:bg-psychology-primary hover:text-white transition-colors px-8 py-4">
                   <Link to="/guide">
                     <BookOpen className="w-5 h-5 mr-2" />
                     了解更多信息


### PR DESCRIPTION
当鼠标移动到部分按钮时：
原有问题
<img width="1152" height="584" alt="image" src="https://github.com/user-attachments/assets/ab13ca28-2c9b-4b02-b599-8edf5fc992f6" />
修复完成后效果
<img width="890" height="314" alt="image" src="https://github.com/user-attachments/assets/6e383af0-9afd-487d-97e9-95a3f3d3fe31" />


- 修复"完整版测评"按钮悬停时文字不清晰的问题
- 修复"开始完整测评"按钮悬停时对比度不足的问题  
- 修复"了解更多信息"按钮悬停时文字看不清的问题
- 为所有 outline 按钮添加悬停时背景色和白色文字
- 添加平滑的颜色过渡动画效果